### PR TITLE
CodeBlock scroll fix

### DIFF
--- a/frontend/src/components/CodeBlock/CodeBlock.svelte
+++ b/frontend/src/components/CodeBlock/CodeBlock.svelte
@@ -159,7 +159,7 @@
     margin: 0rem;
 
     font-size: 0.9rem;
-    grid-template-columns: auto 60px;
+    grid-template-columns: minmax(0px, auto) 60px;
   }
   .buttons {
     display: flex;

--- a/frontend/src/components/CodeBlock/CodeBlock.svelte
+++ b/frontend/src/components/CodeBlock/CodeBlock.svelte
@@ -159,7 +159,7 @@
     margin: 0rem;
 
     font-size: 0.9rem;
-    grid-template-columns: minmax(0px, auto) 60px;
+    grid-template-columns: minmax(0px, 1fr) 60px;
   }
   .buttons {
     display: flex;

--- a/frontend/src/components/QuestionCard.astro
+++ b/frontend/src/components/QuestionCard.astro
@@ -20,7 +20,6 @@ const { question } = Astro.props;
     background-color: var(--sl-color-black);
     flex-direction: column;
     padding: var(--card-padding);
-    gap: var(--card-padding);;
-    overflow: auto;
+    gap: var(--card-padding);
   }
 </style>


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
# Contents ([#16](https://github.com/LyonSyonII/rust-quest/pull/16))

### Fixes
- CodeBlock now scrolls only on the code part (instead on the whole card)
- CodeBlock now scrolls only on the code part (instead of the whole card)

### Uncategorised!
- Merge branch 'main' into dev

<!--- END AUTOGENERATED NOTES --->